### PR TITLE
Enable Viewer to initialize without any custom plots

### DIFF
--- a/shyft_viz/data_viewer.py
+++ b/shyft_viz/data_viewer.py
@@ -153,9 +153,10 @@ class Viewer(object):
 
 
         plt_mode_label = ['Plot_dist_dataset', 'Add_dist_ds_to_rec', 'Del_dist_ds_from_rec', 'Custom_Plot']
+
         self.custom_plt = custom_plt
         self.custom_plt_types = list(self.custom_plt.keys())
-        self.custom_plt_active = self.custom_plt_types[0]
+        self.custom_plt_active = self.custom_plt_types[0] if len(custom_plt) else None
 
         self.data_lim_current = {nm: [0, 1] for nm in self.dist_vars}
 
@@ -209,7 +210,8 @@ class Viewer(object):
 
         self.custom_plt_btn = self.add_radio_button(ax_oper_plots, 'Custom Plots', self.custom_plt_types,
                                                     self.OnCustomPltBtnClk)
-        self.custom_plt_btn.set_active(self.custom_plt_types.index(self.custom_plt_active))
+        if self.custom_plt_active:
+            self.custom_plt_btn.set_active(self.custom_plt_types.index(self.custom_plt_active))
         self.add_data_lim_sliders(ax_min_slider, ax_max_slider)
         self.add_time_slider(ax_time_slider)
         self.add_media_button(ax_navigate)

--- a/shyft_viz/data_viewer.py
+++ b/shyft_viz/data_viewer.py
@@ -153,7 +153,6 @@ class Viewer(object):
 
 
         plt_mode_label = ['Plot_dist_dataset', 'Add_dist_ds_to_rec', 'Del_dist_ds_from_rec', 'Custom_Plot']
-
         self.custom_plt = custom_plt
         self.custom_plt_types = list(self.custom_plt.keys())
         self.custom_plt_active = self.custom_plt_types[0] if len(custom_plt) else None


### PR DESCRIPTION
Viewer init() currently expects len(custom_plt) > 0. Added two tests to prevent crash when custom_plt is empty.