### PR TITLE
Bugfix in bugfix in _time_num_2_idx

### DIFF
--- a/shyft_viz/data_extractors/shyft_multi_regmod_data.py
+++ b/shyft_viz/data_extractors/shyft_multi_regmod_data.py
@@ -34,7 +34,7 @@ class DataExtractor(object):
         t = int(t_num)
         if t < self.t_ax_shyft.start:
             return 0
-        elif t > self.t_ax_shyft.end:
+        elif t >= self.t_ax_shyft.total_period().end:
             return self.t_ax_shyft.n-1
         return self.t_ax_shyft.index_of(t)
 


### PR DESCRIPTION
Update to previous bugfix. Attempt to access t_ax_shyft.end was plain wrong. New attempt uses t_ax_shyft.total_period().end instead, and tests for greater-or-equal instead of just greater.